### PR TITLE
Add php as a requirement in README.md

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,7 @@ Both commands operate on the currently opened file.
 
 ## Requirements
 
+This plugin requires php as a dependency.
 This version works with graphical versions of vim **as well as** terminal versions of vim!
 In the non-gui case, a 256 color terminal is required and the hexcode is approximated using a couple of scripts from [Vim-toCterm](https://github.com/shawncplus/Vim-toCterm).
 


### PR DESCRIPTION
I got an error about php when trying to use your plugin and it turns out it just needed php installed.